### PR TITLE
Fix/max repeats esa

### DIFF
--- a/core/maximal_repeats.py
+++ b/core/maximal_repeats.py
@@ -4,12 +4,14 @@ from dataclasses import dataclass, field
 from typing import Optional, Set, Tuple
 
 repeats_set: set[tuple[tuple[int, int], tuple[int, int]]] = set()
+UNDEFINED: int = -1
+alphabet_set: set[str]
 
 
 @dataclass
-class Node:
-    data: dict[str, int]
-    next: Optional[Node] = None
+class ListNode:
+    data: int
+    next: Optional[ListNode] = None
 
 
 @dataclass
@@ -18,13 +20,16 @@ class Interval:
     lb: int = 0
     rb: int = -1
     child_list: list[Interval] = field(default_factory=list)
-    pos_sets: Node = None
+    pos_sets: dict[str, ListNode] = field(default_factory=dict)
+
+    # def __post_init__(self):
+    #     self.pos_sets = {alphabet: ListNode(UNDEFINED) for alphabet in alphabet_set}
 
     def update_child_list(self, interval: Interval) -> None:
         self.child_list.append(interval)
 
     def __str__(self) -> str:
-        return f"lb={self.rb}, rb={self.rb}, lcp_value={self.lcp_value}"
+        return f"lb={self.lb}, rb={self.rb}, lcp_value={self.lcp_value}, child_list={self.child_list}"
 
 
 class SpecialStack:
@@ -49,59 +54,79 @@ class SpecialStack:
 
 def process(lcp_interval: Interval, suf_tab: list[int], s: str, bwt_table: list[str]) -> None:
     # linked list to union the position sets and save it to the parent node(propagate)
-    pos_set_list_head: Optional[Node] = None
-    prev: Optional[Node] = None
-    # init the alphabet set over the input string
-    alphabet_set: set[str] = set(s)
-    # init the dict that maps the alphabet to a pos p, -1 is for undefined at init
-    alphabet_pos_map: dict[str, int] = {alphabet: -1 for alphabet in alphabet_set}
-    lcp = lcp_interval.lcp_value
+    prev_child_alphabet_post_sets: dict[str, ListNode] = {}
 
     for child_interval in lcp_interval.child_list:
+        lcp = child_interval.lcp_value
+        curr_child_alphabet_pos_sets: dict[str, ListNode] = child_interval.pos_sets
         lb: int = child_interval.lb
         rb: int = child_interval.rb
 
-        for alphabet in alphabet_set:
-            for i in range(lb, rb + 1):
-                if bwt_table[i] == alphabet:
-                    alphabet_pos_map[alphabet] = suf_tab[i]
+        if len(curr_child_alphabet_pos_sets.keys()) == 0:
+            for alphabet in alphabet_set:
+                for i in range(lb, rb + 1):
+                    if bwt_table[i] == alphabet:
+                        if alphabet in curr_child_alphabet_pos_sets:
+                            curr_ptr_head = curr_child_alphabet_pos_sets[alphabet]
+                            curr_ptr = curr_ptr_head
+                            prev_curr_ptr = curr_ptr
 
-        # if this is the first child in this subtree
-        if pos_set_list_head is None:
-            pos_set_list_head = Node(alphabet_pos_map)
-            prev = pos_set_list_head
-        # start linking the previous position sets to be used by the next child
+                            while curr_ptr is not None:
+                                prev_curr_ptr = curr_ptr
+                                curr_ptr = curr_ptr.next
+
+                            prev_curr_ptr.next = ListNode(suf_tab[i])
+                        else:
+                            curr_child_alphabet_pos_sets[alphabet] = ListNode(suf_tab[i])
+        if len(prev_child_alphabet_post_sets.keys()) == 0:
+            prev_child_alphabet_post_sets = curr_child_alphabet_pos_sets
         else:
-            new_node = Node(alphabet_pos_map)
-            new_node.next = prev.next
-            prev.next = new_node
-            prev = new_node
+            for curr_key in curr_child_alphabet_pos_sets:
+                for prev_key in prev_child_alphabet_post_sets:
+                    if curr_key != prev_key:
+                        curr_alphabet_list_head = curr_child_alphabet_pos_sets[curr_key]
+                        prev_alphabet_list_head = prev_child_alphabet_post_sets[prev_key]
+                        curr_alphabet_list_ptr = curr_alphabet_list_head
+                        prev_alphabet_list_ptr = prev_alphabet_list_head
 
-        curr = pos_set_list_head
+                        while curr_alphabet_list_ptr is not None:
+                            prev_alphabet_list_ptr = prev_alphabet_list_head
+                            while prev_alphabet_list_ptr is not None:
+                                p = prev_alphabet_list_ptr.data
+                                p_prime = curr_alphabet_list_ptr.data
 
-        # start processing all the position sets collected up to this child interval
-        while curr is not None:
-            last_alphabet_pos_map: dict[str, int] = curr.data
+                                if p_prime > p and lcp > 0:
+                                    print(f"pair={((p, p + lcp), (p_prime, p_prime + lcp))}")
+                                    pass
 
-            for a in alphabet_set:
-                for b in alphabet_set:
-                    if a != b:
-                        p = last_alphabet_pos_map[a]
-                        p_prime = alphabet_pos_map[b]
+                                prev_alphabet_list_ptr = prev_alphabet_list_ptr.next
 
-                        if p < p_prime != -1 and p != -1 and bwt_table[p] != bwt_table[p_prime]:
-                            repeats_set.add(((p, p + lcp - 1), (p_prime, p_prime + lcp - 1)))
+                            curr_alphabet_list_ptr = curr_alphabet_list_ptr.next
+            for key in curr_child_alphabet_pos_sets:
+                curr_child_ptr_itr = curr_child_alphabet_pos_sets[key]
 
-            curr = curr.next
+                if key in prev_child_alphabet_post_sets:
+                    last_set = prev_child_alphabet_post_sets[key]
+                    prev_ptr_last_set = last_set
 
-    # finally, propagate the computed position sets to the parent interval
-    lcp_interval.pos_sets = pos_set_list_head
+                    while last_set is not None:
+                        prev_ptr_last_set = last_set
+                        last_set = last_set.next
+
+                    prev_ptr_last_set.next = curr_child_ptr_itr
+                else:
+                    prev_child_alphabet_post_sets[key] = curr_child_ptr_itr
+
+    lcp_interval.pos_sets = prev_child_alphabet_post_sets
 
 
 def find_maximal_repeats(s: str, suf_tab: list[int], lcp_table: list[int], bwt_table: list[str]) -> \
         set[tuple[tuple[int, int], tuple[int, int]]]:
     # add the sentinel
     s = s + '$'
+    # init the alphabet set over the input string
+    global alphabet_set
+    alphabet_set = set(s)
     last_interval: Optional[Interval] = None
     stack: SpecialStack = SpecialStack()
 
@@ -133,5 +158,8 @@ def find_maximal_repeats(s: str, suf_tab: list[int], lcp_table: list[int], bwt_t
                 last_interval = None
             else:
                 stack.push(Interval(lcp_table[i], lb, -1, []))
+
+    stack.top().rb = len(lcp_table)
+    process(stack.pop(), suf_tab, s, bwt_table)
 
     return repeats_set

--- a/core/maximal_repeats.py
+++ b/core/maximal_repeats.py
@@ -95,13 +95,15 @@ def process_leaves(lcp_interval: Interval, suf_tab: list[int], bwt_table: list[s
 
 
 def process(lcp_interval: Interval, suf_tab: list[int], bwt_table: list[str]) -> None:
-    # linked list to union the position sets and save it to the parent node(propagate)
+    # this variable saves the union of pos sets of all child intervals of this interval
     prev_child_alphabet_post_sets: PositionSets = {}
     lcp = lcp_interval.lcp_value
 
+    # the smallest interval that has no children is the parent of the leaves under this interval/subtree
     if len(lcp_interval.child_list) == 0:
         process_leaves(lcp_interval, suf_tab, bwt_table)
     else:
+        # process the pos sets propagated to these intervals by their children
         for child_interval in lcp_interval.child_list:
             curr_child_alphabet_pos_sets: PositionSets = child_interval.pos_sets
 
@@ -114,7 +116,6 @@ def process(lcp_interval: Interval, suf_tab: list[int], bwt_table: list[str]) ->
                             curr_alphabet_list_head = curr_child_alphabet_pos_sets[curr_key]
                             prev_alphabet_list_head = prev_child_alphabet_post_sets[prev_key]
                             curr_alphabet_list_ptr = curr_alphabet_list_head
-                            prev_alphabet_list_ptr = prev_alphabet_list_head
 
                             while curr_alphabet_list_ptr is not None:
                                 prev_alphabet_list_ptr = prev_alphabet_list_head
@@ -122,28 +123,28 @@ def process(lcp_interval: Interval, suf_tab: list[int], bwt_table: list[str]) ->
                                     p = prev_alphabet_list_ptr.data
                                     p_prime = curr_alphabet_list_ptr.data
 
-                                    if p_prime > p and lcp > 0:
+                                    if p_prime > p:
                                         maximal_repeats.append(((p, p + lcp), (p_prime, p_prime + lcp)))
 
                                     prev_alphabet_list_ptr = prev_alphabet_list_ptr.next
 
                                 curr_alphabet_list_ptr = curr_alphabet_list_ptr.next
+                # union the lists
                 for key in curr_child_alphabet_pos_sets:
                     curr_child_ptr_itr = curr_child_alphabet_pos_sets[key]
 
+                    # if key is present in prev pos sets, then link the pos set for this key found in this child pos set
                     if key in prev_child_alphabet_post_sets:
-                        last_set = prev_child_alphabet_post_sets[key]
-                        last_set_ptr = last_set
-                        prev_ptr_last_set = last_set
+                        prev_child_ptr = prev_child_alphabet_post_sets[key]
 
-                        while last_set_ptr is not None:
-                            prev_ptr_last_set = last_set_ptr
-                            last_set_ptr = last_set_ptr.next
+                        while prev_child_ptr.next is not None:
+                            prev_child_ptr = prev_child_ptr.next
 
-                        prev_ptr_last_set.next = curr_child_ptr_itr
+                        prev_child_ptr.next = curr_child_ptr_itr
                     else:
                         prev_child_alphabet_post_sets[key] = curr_child_ptr_itr
 
+        # propagate the union of lists after children are processed and all maximal repeats are output
         lcp_interval.pos_sets = prev_child_alphabet_post_sets
 
 

--- a/test/test_match_pattern.py
+++ b/test/test_match_pattern.py
@@ -2,13 +2,11 @@ import unittest
 from typing import Optional
 
 from core.match_pattern import find_pattern
-from core.maximal_repeats import find_maximal_repeats
 from core.utils.STree import STree
 from core.utils import basic_tables_utils
 
 
 class TestMatchPattern(unittest.TestCase):
-    bwt_tab = None
     s: Optional[str] = None
     p: Optional[str] = None
     non_existing_pattern: Optional[str] = None
@@ -18,16 +16,13 @@ class TestMatchPattern(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.s = "xabcyabcwabcyz"
-        cls.p = "a"
+        cls.s = "banana"
+        cls.p = "bana"
         cls.non_existing_pattern = "haha"
         cls.stree = STree()
         cls.stree.build_using_mccreight(cls.s)
         cls.suf_tab = basic_tables_utils.gen_suffix_array(cls.stree)
         cls.lcp_tab = basic_tables_utils.gen_lcp_array(cls.s, cls.suf_tab)
-        cls.bwt_tab = basic_tables_utils.gen_bwt_array(cls.s, cls.suf_tab)
-
-        print(find_maximal_repeats(cls.s, cls.suf_tab, cls.lcp_tab, cls.bwt_tab))
 
     def test_empty_pattern_in_non_empty_string_using_esa(self) -> None:
         self.assertIsNotNone(find_pattern(self.s, "", self.suf_tab, self.lcp_tab))

--- a/test/test_match_pattern.py
+++ b/test/test_match_pattern.py
@@ -2,11 +2,13 @@ import unittest
 from typing import Optional
 
 from core.match_pattern import find_pattern
+from core.maximal_repeats import find_maximal_repeats
 from core.utils.STree import STree
 from core.utils import basic_tables_utils
 
 
 class TestMatchPattern(unittest.TestCase):
+    bwt_tab = None
     s: Optional[str] = None
     p: Optional[str] = None
     non_existing_pattern: Optional[str] = None
@@ -16,13 +18,16 @@ class TestMatchPattern(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.s = "banana"
-        cls.p = "bana"
+        cls.s = "xabcyabcwabcyz"
+        cls.p = "a"
         cls.non_existing_pattern = "haha"
         cls.stree = STree()
         cls.stree.build_using_mccreight(cls.s)
         cls.suf_tab = basic_tables_utils.gen_suffix_array(cls.stree)
         cls.lcp_tab = basic_tables_utils.gen_lcp_array(cls.s, cls.suf_tab)
+        cls.bwt_tab = basic_tables_utils.gen_bwt_array(cls.s, cls.suf_tab)
+
+        print(find_maximal_repeats(cls.s, cls.suf_tab, cls.lcp_tab, cls.bwt_tab))
 
     def test_empty_pattern_in_non_empty_string_using_esa(self) -> None:
         self.assertIsNotNone(find_pattern(self.s, "", self.suf_tab, self.lcp_tab))

--- a/test/test_match_pattern.py
+++ b/test/test_match_pattern.py
@@ -2,11 +2,13 @@ import unittest
 from typing import Optional
 
 from core.match_pattern import find_pattern
+from core.maximal_repeats import find_maximal_repeats
 from core.utils.STree import STree
 from core.utils import basic_tables_utils
 
 
 class TestMatchPattern(unittest.TestCase):
+    bwt_tab = None
     s: Optional[str] = None
     p: Optional[str] = None
     non_existing_pattern: Optional[str] = None


### PR DESCRIPTION
- Change the logic of how the union of lists was working for children
- Fix propagation of list after all pos sets are processed of its children
- Use a list instead of sets to save repeats. Also, introduce simpler typings.
- The new code mirrors the logic from STree maximal repeats, just like the paper does. There were few errors in the code under `process`
- I will release a new PR with tests that matches the repeats found using STree and ESA and compares the timing, once both PRs are approved and merged.